### PR TITLE
added the ability to loosely diff without checksum comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,37 @@ config entities in a bundle). To perform this operation, use the diff command:
 ./graphman.sh diff --input tooBig.json --input whatToCut.json --output trimmed.json
 ```
 
+If you wish to subtract entities from whatToCut.json even if they are different from tooBig.json
+you can remove from checksum property in whatToCut.json. For example if whatToCut.json contains:
+
+```
+{
+    "keys": [
+        {
+            "alias": "ssl"
+        }
+    ],
+    "listenPorts": [
+        {
+            "name": "Default HTTP (8080)"
+        },
+        {
+            "name": "Default HTTPS (8443)"
+        },
+        {
+            "name": "Default HTTPS (9443)"
+        },
+        {
+            "name": "Node HTTPS (2124)"
+        }
+    ]
+}
+```
+
+Then the subtract command will always remove the default ssl key and default listednPorts no matter their
+value in the source.
+
+
 ## Using the Graphman combine command
 
 You can combine two configuration bundles using the combine command:

--- a/modules/graphman-operation-diff.js
+++ b/modules/graphman-operation-diff.js
@@ -90,7 +90,10 @@ function diffEntities(leftEntities, rightEntities, resultEntities, resultBundle,
     leftEntities.forEach(left => {
         const matchingEntity = butils.findMatchingEntity(rightEntities, left);
 
-        if (!matchingEntity || matchingEntity.checksum !== left.checksum) {
+        if (!matchingEntity) {
+            utils.info("  selecting " + butils.entityDisplayName(left));
+            resultEntities.push(left);
+        } else if (matchingEntity.checksum != null && matchingEntity.checksum !== left.checksum) { // if matchingEntity.checksum is not present, we assume user explicitely wants to ignore same entity that have different value
             utils.info("  selecting " + butils.entityDisplayName(left));
             resultEntities.push(left);
         }


### PR DESCRIPTION
Please review this change to the diff capability which allows the manipulation of common entities out of bundles by diffing them by id/name only and exclude entities that have same id even if their value differs.

Normal diff is unchanged. In order to take advantage of this new capability, you have to remove the checksum from the second argument bundle of the diff command. See the Readme changes for usage.