### PR TITLE
NORALLY: implode fails for keys folder

### DIFF
--- a/modules/graphman-operation-implode.js
+++ b/modules/graphman-operation-implode.js
@@ -69,8 +69,9 @@ let type1Imploder = (function () {
                             entity.pem = utils.readFile(`${typeDir}/${filename}`);
                         }
 
-                        if (entity.certChain && entity.certChain.endsWith(".certchain.pem}")) {
-                            const filename = entity.certChain.match(/{(.+)}/)[1];
+                        const certChain = entity.certChain;
+                        if (certChain && typeof certChain === 'string' && certChain.endsWith(".certchain.pem}")) {
+                            const filename = certChain.match(/{(.+)}/)[1];
                             const lines = utils.readFile(`${typeDir}/${filename}`).split(/\r?\n/);
                             let data = "";
 


### PR DESCRIPTION
Imploding a folder containing keys fails with the below error.

```
graphman.bat implode --input keys --output keys.json
error encountered while processing the graphman operation, TypeError, entity.certChain.endsWith is not a function
```

This issue exists with 1.1 release only. _certChain_ field of _keys_ is a string array. Implode logic is inspecting the value as string. 

Change is made to fix the problem with the additional type checking. 