### PR TITLE
NORALLY: supporting multiple gateway profiles

### DIFF
--- a/graphman.configuration
+++ b/graphman.configuration
@@ -1,20 +1,17 @@
 {
-    "sourceGateway": {
-        "address": "https://localhost:8443/graphman",
-        "username": "admin",
-        "password": "7layer",
-        "rejectUnauthorized": false,
-        "passphrase": "7layer"
-    },
-    "targetGateway": {
-        "address": "https://localhost:8443/graphman",
-        "username": "admin",
-        "password": "7layer",
-        "rejectUnauthorized": false,
-        "passphrase": "7layer"
+    "gateways": {
+        "default": {
+            "address": "https://localhost:8443/graphman",
+            "username": "admin",
+            "password": "7layer",
+            "rejectUnauthorized": false,
+            "passphrase": "7layer",
+            "allowMutations": false
+        }
     },
 
-    "properties": {
-        "policyCodeFormat": "xml"
+    "options": {
+        "policyCodeFormat": "xml",
+        "keyFormat": "p12"
     }
 }

--- a/modules/graphman-operation-diff.js
+++ b/modules/graphman-operation-diff.js
@@ -4,17 +4,17 @@ const utils = require("./graphman-utils");
 const butils = require("./graphman-bundle");
 const queryBuilder = require("./graphql-query-builder");
 const opExport = require("./graphman-operation-export");
-const opRenew = require("./graphman-operation-renew");
 
 module.exports = {
     run: function (params) {
         const bundles = [];
-        const config = graphman.configuration(params);
 
-        bundles.push(readBundle(config.sourceGateway,
-            Array.isArray(params.input) ? params.input[0] : params.input));
-        bundles.push(readBundle(config.targetGateway,
-            Array.isArray(params.input) ? params.input[1] : null));
+        if (Array.isArray(params.input) && params.input.length >= 2) {
+            bundles.push(readBundleFrom(params.input[0]));
+            bundles.push(readBundleFrom(params.input[1]));
+        } else {
+            throw utils.newError("not enough arguments")
+        }
 
         Promise.all(bundles).then(results => {
             const leftBundle = results[0];
@@ -25,53 +25,39 @@ module.exports = {
             if (!diffBundle.goidMappings.length) delete diffBundle.goidMappings;
             if (!diffBundle.guidMappings.length) delete diffBundle.guidMappings;
 
-            if (params.renew) {
-                Promise.all(opRenew.renew(config.sourceGateway, diffBundle)).then(results => {
-                    const renewedBundle = {};
-
-                    results.forEach(item => {
-                        // process parts (SMF entities) if exists
-                        if (item.parts) {
-                            utils.writePartsResult(utils.parentPath(params.output), item.parts);
-                            delete item.parts;
-                        }
-
-                        // merge the intermediate bundles
-                        Object.assign(renewedBundle, item);
-                    });
-
-                    renewedBundle.properties = leftBundle.properties;
-                    utils.writeResult(params.output, butils.sort(renewedBundle));
-                });
-            } else {
-                diffBundle.properties = leftBundle.properties;
-                utils.writeResult(params.output, butils.sort(diffBundle));
-            }
+            diffBundle.properties = leftBundle.properties;
+            utils.writeResult(params.output, butils.sort(diffBundle));
         });
     },
 
     usage: function () {
-        console.log("    diff [--input <input-file> --input <input-file>] [--output <output-file>] [<options>]");
+        console.log("    diff [--input <input-file-or-gateway> --input <input-file-or-gateway>] [--output <output-file>] [<options>]");
         console.log("        # evaluates the differences between bundles or gateways.");
-        console.log("        # when input bundles are missing, bundles will be pulled from the source and target gateways.");
-        console.log("        # when second input bundle is missing, it will be pulled from the target gateway.");
-        console.log("      --renew");
-        console.log("        # to renew the diff entities from the source gateway");
+        console.log("        # input can be a bundle file or a gateway name if it precedes with '@' special character.");
+        console.log("        # when gateway is specified as input, summary bundle will be pulled for comparison.");
     }
 }
 
-function readBundle(gateway, file) {
+function readBundleFrom(fileOrGateway) {
+    if (fileOrGateway.startsWith('@')) {
+        const gateway = graphman.gatewayConfiguration(fileOrGateway.substring(1));
+        if (!gateway.address) throw utils.newError(`${gateway.name} gateway details are missing`);
+        return readBundleFromGateway(gateway);
+    } else {
+        return new Promise(function (resolve) {
+            resolve(utils.readFile(fileOrGateway));
+        });
+    }
+}
+
+function readBundleFromGateway(gateway) {
     return new Promise(function (resolve) {
-        if (file) {
-            resolve(utils.readFile(file));
-        } else {
-            utils.info("retrieving the gateway configuration summary from " + gateway.address);
-            opExport.export(
-                gateway,
-                queryBuilder.build("summary", {}, graphman.configuration().properties),
-                data => resolve(data.data)
-            );
-        }
+        utils.info(`retrieving ${gateway.name} gateway configuration summary`);
+        opExport.export(
+            gateway,
+            queryBuilder.build("summary", {}, graphman.configuration().options),
+            data => resolve(data.data)
+        );
     });
 }
 

--- a/modules/graphman-utils.js
+++ b/modules/graphman-utils.js
@@ -16,7 +16,18 @@ const FINE_LEVEL = 3;
 const DEBUG_LEVEL = 10;
 let logLevel = INFO_LEVEL;
 
+class GraphmanOperationError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'GraphmanOperationError';
+    }
+}
+
 module.exports = {
+    newError: function (msg) {
+        return new GraphmanOperationError(msg);
+    },
+
     loggingAt: function (level) {
         if (level === 'warn' && logLevel === WARN_LEVEL) return true;
         else if (level === 'info' && logLevel === INFO_LEVEL) return true;
@@ -160,6 +171,10 @@ module.exports = {
         console.log(text
             .replaceAll("\\r\\n", "\n")
             .replaceAll("\\n", "\n"));
+    },
+
+    error: function (message, ...args) {
+        this.log("[error] " + message, args);
     },
 
     warn: function (message, ...args) {

--- a/modules/graphman.js
+++ b/modules/graphman.js
@@ -16,15 +16,10 @@ module.exports = {
     metadata: null,
 
     init: function (params) {
-        let config = JSON.parse(utils.readFile(utils.home() + "/graphman.configuration"));
-
-        if (params.sourceGateway) {
-            Object.assign(config.sourceGateway, params.sourceGateway);
-        }
-
-        if (params.targetGateway) {
-            Object.assign(config.targetGateway, params.targetGateway);
-        }
+        const config = JSON.parse(utils.readFile(utils.home() + "/graphman.configuration"));
+        config.options = makeOptions(config.options || {});
+        config.gateways = makeGateways(config.gateways || {});
+        config.defaultGateway = config.gateways['default'];
 
         config.version = VERSION;
         config.defaultSchemaVersion = SCHEMA_VERSION;
@@ -33,15 +28,26 @@ module.exports = {
             utils.warn(`specified schema (${config.schemaVersion}) is missing, falling back to the default`);
         }
 
-        config.properties = config.properties || {};
-        if (!config.properties.policyCodeFormat) config.properties.policyCodeFormat = "xml";
-
         this.metadata = gqlschema.build(config.schemaVersion, false);
         this.loadedConfig = config;
     },
 
     configuration: function () {
         return this.loadedConfig;
+    },
+
+    gatewayConfiguration: function (name) {
+        return name ? Object.assign({name: name}, this.configuration().gateways[name]) : null;
+    },
+
+    overridenGatewayConfiguration: function (obj) {
+        if (!obj) return null;
+
+        utils.warn("overriding the gateway details via parameter is deprecated, make use of multiple gateway definitions");
+        let gateway = Object.assign({}, this.configuration().defaultGateway || {});
+        Object.assign(gateway, obj);
+        gateway.name = gateway.address;
+        return gateway;
     },
 
     schemaMetadata: function () {
@@ -174,4 +180,33 @@ function getPartsFromRawRequest(options) {
     }
 
     return options.parts;
+}
+
+function makeOptions(options) {
+    return Object.assign({
+        "policyCodeFormat": "xml",
+        "keyFormat": "p12"
+    }, options);
+}
+
+function makeGateways(gateways) {
+    // populate default gateway if no gateway profiles are defined
+    if (!Object.keys(gateways).length) {
+        gateways['default'] = {
+            "address": "https://localhost:8443/graphman",
+            "username": "admin",
+            "password": "7layer",
+            "rejectUnauthorized": false,
+            "passphrase": "7layer",
+            "allowMutations": false
+        };
+    }
+
+    // define entry for default gateway for error reporting
+    if (!gateways['default']) {
+        gateways['default'] = {};
+    }
+
+    Object.entries(gateways).forEach(([key, item]) => item['name'] = key);
+    return gateways;
 }

--- a/modules/graphql-query-builder.js
+++ b/modules/graphql-query-builder.js
@@ -123,14 +123,14 @@ function buildQuery(queryIdPrefix, queryIdSuffix) {
 function substituteAlternativeFields(text, options) {
     // substitute alternative field for policy code (xml or json or yaml or code)
     if (options.policyCodeFormat && options.policyCodeFormat !== "xml") {
-        text = text.replaceAll(/(policy|policyRevision|policyRevisions)[^{]+[{][^}]+}/g, function (subtext) {
+        text = text.replaceAll(/(policy|policyRevision|policyRevisions)[^{]*[{][^}]+}/g, function (subtext) {
             return subtext.replace("xml", options.policyCodeFormat);
         });
     }
 
     // substitute alternative field for key detail (p12 or pem)
     if (options.keyFormat && options.keyFormat !== "p12") {
-        text = text.replaceAll(/(keys|keyBy[\w]+)[^{]+[{][^}]+}/g, function (subtext) {
+        text = text.replaceAll(/(keys|keyBy[\w]+)[^{]*[{][^}]+}/g, function (subtext) {
             return subtext.replace("p12", options.keyFormat);
         });
     }

--- a/modules/main.js
+++ b/modules/main.js
@@ -22,8 +22,10 @@ try {
         operation(op).run(params);
     }
 } catch (e) {
-    if (typeof e !== 'object') {
-        console.log(e);
+    if (typeof e === 'string') {
+        utils.error(e);
+    } else if (typeof e === 'object' && e.name === 'GraphmanOperationError') {
+        utils.error(e.message);
     } else if (utils.loggingAt('debug')) {
         console.log(e);
     } else {

--- a/queries/keyByAlias.gql
+++ b/queries/keyByAlias.gql
@@ -1,13 +1,5 @@
 query keyByAlias($alias: String!) {
     keyByAlias(alias : $alias) {
-        goid
-        keystoreId
-        alias
-        checksum
-
-        keyType
-        subjectDn
-        p12
-        certChain
+        {{Key}}
     }
 }

--- a/schema/metadata-base.json
+++ b/schema/metadata-base.json
@@ -399,7 +399,8 @@
             "ListenPort": "hardwiredService",
             "L7Policy": "policyRevision,policyRevisions",
             "L7Service": "policyRevision,policyRevisions",
-            "ActiveConnector": "hardwiredService"
+            "ActiveConnector": "hardwiredService",
+            "Key": "pem"
         }
     },
     "enumTypes": [],


### PR DESCRIPTION
Existing graphman configuration allows the user to work with two gateway profiles named as _sourceGateway_ and _targetGateway_.
With this, user is allowed to work with multiple gateway profiles. Configured gateway profiles can be referenced as an option (**_--gateway name_**) while executing the **export**, **import**, **renew**, **diff** operations.

**Examples:**
- `graphman.bat export --using all --gateway some-gateway`
- `graphman.bat import --input some-bundle.json --gateway some-other-gateway`

In the above operations, if gateway option is not specified, it will be defaulted to **"default"** gateway profile.

- `graphman.bat diff --input some-bundle.json --input some-other-bundle.json`
- `graphman.bat diff --input some-bundle.json --input @some-gateway`

In the above diff command, input can be a bundle or gateway. If gateway, make sure it is prefixed with '@' special char.

Default graphman configuration is as follows:

```
{
    "gateways": {
        "default": {
            "address": "https://localhost:8443/graphman",
            "username": "admin",
            "password": "7layer",
            "rejectUnauthorized": false,
            "passphrase": "7layer",
            "allowMutations": false
        }
    },

    "options": {
        "policyCodeFormat": "xml",
        "keyFormat": "p12"
    }
}
```

By default, gateways are protected from the accidental mutations, hence they will be ignored. In order to allow the mutations, set the "**allowMutations**" option to **true**.

Policy code can be seen in multiple formats (xml, json, yaml, code). By default, it will be exported in xml format. This can be changed to other supported formats by chanding the **policyCodeFormat** option.

Similarly, key format can be changed using **keyFormat** option. By default, keys will be seen in **p12** format. Other supported variant is **pem**.
 