### PR TITLE
NORALLY: avoiding pem field for keys by default

### DIFF
--- a/queries/all.gql
+++ b/queries/all.gql
@@ -51,7 +51,7 @@ query all {
         {{JmsDestination}}
     }
     keys {
-        {{Key}}
+        {{Key:-pem}}
     }
     ldapIdps {
         {{LdapIdp}}

--- a/queries/keyByAlias.gql
+++ b/queries/keyByAlias.gql
@@ -1,5 +1,5 @@
 query keyByAlias($alias: String!) {
     keyByAlias(alias : $alias) {
-        {{Key}}
+        {{Key:-pem}}
     }
 }

--- a/queries/service.gql
+++ b/queries/service.gql
@@ -8,22 +8,10 @@ query serviceByResolutionPath ($resolutionPath: String!, $includeAllDependencies
             }
         }
         policyRevision @include (if: $includePolicyRevision) {
-            goid
-            ordinal
-            active
-            comment
-            author
-            time
-            xml
+            {{PolicyRevision:-json,yaml,code}}
         }
         policyRevisions @include (if: $includePolicyRevisions) {
-            goid
-            ordinal
-            active
-            comment
-            author
-            time
-            xml
+            {{PolicyRevision:-json,yaml,code}}
         }
     }
 }


### PR DESCRIPTION
Avoiding pem field for keys by default. So that, key details field can be rightly controlled using **keyFormat** option.