### PR TITLE
adding query fipUserByName and fix sanitizing

### DIFF
--- a/queries/fipUserByName.gql
+++ b/queries/fipUserByName.gql
@@ -1,0 +1,5 @@
+query fipUserByName($providerName: String!, $name: String!) {
+    fipUserByName(providerName : $providerName, name : $name) {
+        {{FipUser}}
+    }
+}

--- a/queries/fipUserByName.json
+++ b/queries/fipUserByName.json
@@ -1,0 +1,7 @@
+{
+  "query": "{{fipUserByName.gql}}",
+  "variables": {
+    "providerName": "?",
+    "name" : "?"
+  }
+}

--- a/schema/metadata-base.json
+++ b/schema/metadata-base.json
@@ -75,12 +75,6 @@
             "idField": "name",
             "prefix": "encassConfig"
         },
-        "Fip": {
-            "pluralMethod": "fips",
-            "singularMethod": "fipByName",
-            "idField": "name",
-            "prefix": "fip"
-        },
         "FipGroup": {
             "pluralMethod": "fipGroups",
             "singularMethod": "fipGroupByName",
@@ -100,6 +94,12 @@
                 "providerName"
             ],
             "prefix": "fipUser"
+        },
+        "Fip": {
+            "pluralMethod": "fips",
+            "singularMethod": "fipByName",
+            "idField": "name",
+            "prefix": "fip"
         },
         "GlobalPolicy": {
             "pluralMethod": "globalPolicies",


### PR DESCRIPTION
I was playing around with fipUserByName.
After adding the appropriate gql and json file, I was able to export a fipUser by:
graphman.sh export --using fipUserByName --variables.providerName "just a test" --variables.name mm-test

So far, so good.
However, I recognized that the output looked like:
[info] sanitizing **fipUserByName to fips**
{
  **"fips":** [
    {
      "goid": "359cfae8ad45fa5a152c5ca12eef0272",
      "name": "mm-test",
      "login": "mm-test",
      "providerName": "just a test",
      "checksum": "53215b321e2a6e34cdd6ada4933476b7dd76f882",
      "subjectDn": "cn=mm-test",
      "email": "",
      "memberOf": []
    }
  ],
  "properties": {
    "meta": {
      "id": "47693221-a9dc-46ff-8263-9c9271309de4",
      "name": "Gateway Graphman Bundle - 2024-04-29T18:19:50.700+02:00",
      "author": "admin",
      "hostname": "192.168.2.202",
      "timestamp": "2024-04-29T18:19:50.700+02:00"
    },
    "defaultAction": "NEW_OR_UPDATE"
  }
}

I aligned metadata-base.json, by moving the "types.Fip" entry behind the "types.FipGroup" entry. As I believe, that it needs to be the last one of the "Fip..." related entries. Its obviously the less significant one.
This solved my issue.
Regards
...Michael
