### PR TITLE
filter enhancements

### DIFF
--- a/modules/graphman-operation-export.js
+++ b/modules/graphman-operation-export.js
@@ -116,8 +116,13 @@ module.exports = {
         console.log("  --filter.by <field-name>");
         console.log("    use this option to filter the exported entities by some field");
         console.log();
-        console.log("  --filter.[equals|startsWith|endsWith|contains] <value>");
+        console.log("  --filter.[equals|startsWith|endsWith|contains|lessThan|greaterThan] <value>");
         console.log("    use this option to choose the matching criteria to filter the exported entities");
+        console.log("    lessThan & greaterThan can take date values like 2024-05-31, to compare against date attributes");
+        console.log();
+        console.log("  --filter.not false|true");
+        console.log("    false - default");
+        console.log("    true - invert the condition");
         console.log();
         console.log("  --options.<name> <value>");
         console.log("    specify options as name-value pair(s) to customize the operation");


### PR DESCRIPTION
Suggestions for  filter capabilities enhancements.
- filter.contains : support of regex.
- filter.lessThan and filter.greaterThan : Date and string support.
- filter.not : support of result invert.

filter constraint "contains" was adopted to support regular expressions. Example:
`graphman.sh export --using policies --gateway ... --output ... --filter.by name --filter.contains "[Tt][Ee][Ss][Tt].*"`


filter constraints "lessThan" and "greaterThan" were added primarily to support Date comparisions for trusted Certifiactes, to gather certs for renewal : example:
`graphman.sh export --using trustedCerts --gateway ... --output ... --filter.by notAfter --filter.lessThan 2024-07-31 `
will result in all Certs that will expire after 31.07.2024

filter constraint "not" was introduced to easily invert the filter criterias.
`graphman.sh export --using policies --gateway ... --output ... --filter.by name --filter.contains ".*[Tt][Ee][Ss][Tt].*" --filter.not true`
