### PR TITLE
explode enhancement decodeBase64

### DIFF
--- a/modules/graphman-operation-explode.js
+++ b/modules/graphman-operation-explode.js
@@ -182,18 +182,6 @@ let type1Exploder = (function () {
             return(plainXml);
     }
 
-    function escapeXml(unsafe) {
-        return unsafe.replace(/[<>&'"]/g, function (c) {
-            switch (c) {
-                case '<': return '&lt;';
-                case '>': return '&gt;';
-                case '&': return '&amp;';
-                case '\'': return '&apos;';
-                case '"': return '&quot;';
-            }
-        });
-    }
-
     function escapeEot(unsafe) {
         //escape potential end of code characters '"/>' by '&quoted_end_of_tag';
         return unsafe.replace(/"\/>/g,"&quoted_end_of_tag;");


### PR DESCRIPTION
Suggestion for explode/implode enhancement.

explode
- adding options.decodeBase64 : decoding Base64 encoded tags.
- adding options.noProperties : properties-bundle.json will not be created.

implode
- encoding Base64 decodeded tags.

decodeBase64 :
Especially when comparing policy versions in GitLab it is helpful to understand the differences with decoded Base64 Tags.
The explode will substitute "Base64...." tags by "DecodedBase64 tags and replacing the encode value by its decoded version
The implode does the opposite, converting the decoded stuff to the encoded again.
So, the result of implode looks exactly as the the not yet exploded bundle.
Example:
`graphman.sh explode --input policy.json --output policy --options.level 2 --options.decodeBase64 true`

noProperties:
In our scenarios, extensively using export and explode to create deployment packages, and finally working with GitLab to understand package contents and finalizing the package content the properties-bundle.json file was always more disturbing, than helpful. 
Hence, I added the option to omit the properties bundle creation.
Example:
`graphman.sh explode --input policy.json --output policy --options.level 2 --options.decodeBase64 true --options.noProperties true`