### PR TITLE
diff enhancement : fullDiff option

### DIFF
--- a/modules/graphman-operation-diff.js
+++ b/modules/graphman-operation-diff.js
@@ -28,7 +28,8 @@ module.exports = {
             const rightBundle = results[1];
             const diffBundle = {goidMappings: [], guidMappings: []};
 
-            if (params.fullDiff){
+            console.log("params"+JSON.stringify(params,null,4));
+            if (params.options && params.options.fullDiff){
                 diffBundle["updates"] = {};
                 diffBundle["inserts"] = {};
                 diffBundle["deletes"] = {};
@@ -66,8 +67,9 @@ module.exports = {
         console.log("  --output <output-file>");
         console.log("    specify the file to capture the diff report");
         console.log();
-        console.log("  --fullDiff");
-        console.log("    deviding resources into updates, inserts and deletes.");
+        console.log("  --options.fullDiff false|true");
+        console.log("    true  : deviding resources into updates, inserts and deletes.");
+        console.log("    false : default , normal diff.");
         
     }
 }

--- a/modules/graphman-operation-explode.js
+++ b/modules/graphman-operation-explode.js
@@ -77,6 +77,15 @@ let type1Exploder = (function () {
                 } else if (key === "properties") {
                     utils.info(`capturing ${key} to bundle-properties.json`);
                     utils.writeFile(`${outputDir}/bundle-properties.json`, entities);
+                } else if (key === "updates") {
+                    utils.info(`exploding updates int ${outputDir}/updates`);
+                    this.explode( bundle.updates, outputDir+"/updates", options);
+                } else if (key === "inserts") {
+                    utils.info(`exploding inserts int ${outputDir}/inserts`);
+                    this.explode( bundle.inserts, outputDir+"/inserts", options);
+                } else if (key === "deletes") {
+                    utils.info(`exploding deletes int ${outputDir}/deletes`);
+                    this.explode( bundle.deletes, outputDir+"/deletes", options);
                 }
             });
         }

--- a/modules/graphman-operation-implode.js
+++ b/modules/graphman-operation-implode.js
@@ -47,6 +47,21 @@ let type1Imploder = (function () {
         implode: function (inputDir) {
             const bundle = {};
 
+            const updatesDir = utils.path(inputDir, 'updates');
+            if (utils.existsFile(updatesDir)) {
+                loopdir(updatesDir,bundle,"updates");
+            }
+
+            const insertsDir = utils.path(inputDir, 'inserts');
+            if (utils.existsFile(insertsDir)) {
+                loopdir(insertsDir,bundle,"inserts");
+            }
+
+            const deletesDir = utils.path(inputDir, 'deletes');
+            if (utils.existsFile(deletesDir)) {
+                loopdir(deletesDir,bundle,"deletes");
+            }
+            
             utils.listDir(inputDir).forEach(item => {
                 let subDir = inputDir + "/" + item;
                 if (utils.isDirectory(subDir)) {
@@ -64,6 +79,17 @@ let type1Imploder = (function () {
         }
     };
 
+    function loopdir (inputDir,bundle,property) {
+        utils.listDir(inputDir).forEach(item => {
+            let subDir = inputDir + "/" + item;
+            if (utils.isDirectory(subDir)) {
+                utils.info("imploding " + item);
+                if(!bundle[property]) bundle[property] = {};
+                readEntities(subDir, item, bundle[property]);
+            }
+        });
+    }
+    
     function readEntities(typeDir, type, bundle) {
         if (type === 'tree') {
             readFolderableEntities(typeDir, bundle);


### PR DESCRIPTION
Suggestion for diff enhancement

the new option fullDiff separates differences into updates, inserts and deletes
The diff result bundle lists the results in a main structure looking like:
```
{
    "updates" : { ... },
    "inserts" : { ... },
    "deletes" : { ... }
}
```
explode , implode functions taking care about this structure

This capability is helpful especially in a rollback situation, when you want to identify what exactly will happen, when doing a rollback.
Example:
`graphman.sh diff --input ToBe-bundle.json --input From-bundle.json --output ToDo-bundle.json --options.fullDiff true`

It works best with exported bundles, and not with gateway references, especially in regard to what needs to be deleted.
The resources to be deleted are taken from the 2nd input. In case of a gateway reference "@..." only the summary properties will be included. That might not be sufficient data for an actual deletion operation.(e.g. clusterProperty)
