### PR TITLE
enhancement explode / implode : Adding User certs and fip certs to options.level == 1 pem creation.

### DIFF
--- a/modules/graphman-operation-implode.js
+++ b/modules/graphman-operation-implode.js
@@ -91,11 +91,23 @@ let type1Imploder = (function () {
                         }
                     }
 
-                    if (type === "trustedCerts") {
+                    if (type.match(/trustedCerts|fipUsers|internalUsers|federatedUsers/)) {
                         if (entity.certBase64 && entity.certBase64.endsWith(".pem}")) {
                             const filename = entity.certBase64.match(/{(.+)}/)[1];
                             let data = readCertFile(`${typeDir}/${filename}`, false);
                             entity.certBase64 = data[0];
+                        }
+                    }
+
+                    if (type.match(/fips/)) {
+                        if (entity.certificateReferences && Array.isArray(entity.certificateReferences) && entity.certificateReferences.length > 0) {
+                            entity.certificateReferences.forEach(function (cert) {
+                                if (cert.certBase64 && cert.certBase64.endsWith(".pem}")) {
+                                    const filename = cert.certBase64.match(/{(.+)}/)[1];
+                                    let data = readCertFile(`${typeDir}/${filename}`, false);
+                                    cert.certBase64 = data[0];
+                                }
+                            });
                         }
                     }
 


### PR DESCRIPTION
Suggestion for explode / implode enhancement.

explode : Adding User and fips certs to options.level == 1 pem creation.
implode : handling User and fips pem files on implode

Not all certificate data is available in the cert related json properties.
Hence, in our scenario, we are using the pem files to find certs that will expire in some time with the help of openssl.
To not miss any cert in use (maintained by the gateway) , we have added the internalUser certs and federatedUsers certs (aka. fipUsers) to get pem cert files created on options.level >= 1
I also added to extract the fips.certificateReferences to create the related pem files.
There is no need to handle federatedIdp.trustedCerts, as those do not contain the certBase64 property anymore.

Once exploded, we can then simply use a 
`find <exploded_dir> -name "*.pem"`
to find all certs and then openssl to gather all necessary info.
openssl can also be used to gather all necessary data to create a new CSR.
