### PR TITLE
NORALLY: publishing the artifacts to local npm registry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
                    layer7Graphman=$(ls -d ./build/dist/layer7-graphman-*.tgz)
                    layer7GraphmanWrapper=$(ls -d ./build/dist/layer7-graphman-cli-*.tar.gz)
                    npm publish ${layer7Graphman} --registry https://${ARTIFACTORY_ARTIFACT_NPM_PATH}
-                   curl -v -i -u $ARTIFACTORY_CREDS_USR:$ARTIFACTORY_CREDS_PSW  -T ${layer7GraphmanWrapper}  "${ARTIFACTORY_UPLOAD_PATH}"
+                   #curl -v -i -u $ARTIFACTORY_CREDS_USR:$ARTIFACTORY_CREDS_PSW  -T ${layer7GraphmanWrapper}  "${ARTIFACTORY_UPLOAD_PATH}"
                    rm -rf ./.npmrc
                    '''
                 echo "published Graphman-client artifacts to artifactory"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
                     sh './build.sh'
                     sh "mkdir -p BuildArtifact"
                     sh "du -h"
-                    sh "cp ./build/dist/graphman-* BuildArtifact"
+                    sh "cp ./build/dist/layer7-graphman-* BuildArtifact"
                 }
             }
         }
@@ -53,8 +53,8 @@ pipeline {
                    cat ./.npmrc
 
                    echo start publishing the artifacts
-                   layer7Graphman=$(ls -d ./build/dist/graphman-*.tgz)
-                   layer7GraphmanWrapper=$(ls -d ./build/dist/graphman-cli-*.tar.gz)
+                   layer7Graphman=$(ls -d ./build/dist/layer7-graphman-*.tgz)
+                   layer7GraphmanWrapper=$(ls -d ./build/dist/layer7-graphman-cli-*.tar.gz)
                    npm publish ${layer7Graphman} --registry https://${ARTIFACTORY_ARTIFACT_NPM_PATH}
                    curl -v -i -u $ARTIFACTORY_CREDS_USR:$ARTIFACTORY_CREDS_PSW  -T ${layer7GraphmanWrapper}  "${ARTIFACTORY_UPLOAD_PATH}"
                    rm -rf ./.npmrc

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
         ARTIFACTORY_CREDS = credentials('ARTIFACTORY_USERNAME_TOKEN')
         ARTIFACTORY_ARTIFACT_PATH = 'usw1.packages.broadcom.com/artifactory'
         ARTIFACTORY_ARTIFACT_NPM_PATH = "${env.ARTIFACTORY_ARTIFACT_PATH}/api/npm/apim-npm-dev-local/"
+        ARTIFACTORY_UPLOAD_PATH = "${env.ARTIFACTORY_ARTIFACT_PATH}/apim-npm-dev-local/@layer7/graphman/-/@layer7/"
         ARTIFACTORY_EMAIL = 'bld-apim.teamcity@broadcom.com'
     }
     parameters {
@@ -35,7 +36,7 @@ pipeline {
                     sh './build.sh'
                     sh "mkdir -p BuildArtifact"
                     sh "du -h"
-                    sh "cp ./build/dist/layer7-graphman* BuildArtifact"
+                    sh "cp ./build/dist/graphman-* BuildArtifact"
                 }
             }
         }
@@ -52,10 +53,10 @@ pipeline {
                    cat ./.npmrc
 
                    echo start publishing the artifacts
-                   export layer7Graphman=$(ls -d ./build/dist/layer7-graphman-*.tgz)
-                   export layer7GraphmanWrapper=$(ls -d ./build/dist/layer7-graphman-wrapper*)
+                   layer7Graphman=$(ls -d ./build/dist/graphman-*.tgz)
+                   layer7GraphmanWrapper=$(ls -d ./build/dist/graphman-cli-*.tar.gz)
                    npm publish ${layer7Graphman} --registry https://${ARTIFACTORY_ARTIFACT_NPM_PATH}
-                   npm publish ${layer7GraphmanWrapper} --registry https://${ARTIFACTORY_ARTIFACT_NPM_PATH}
+                   curl -v -i -u $ARTIFACTORY_CREDS_USR:$ARTIFACTORY_CREDS_PSW  -T ${layer7GraphmanWrapper}  "${ARTIFACTORY_UPLOAD_PATH}"
                    rm -rf ./.npmrc
                    '''
                 echo "published Graphman-client artifacts to artifactory"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     environment {
         ARTIFACTORY_CREDS = credentials('ARTIFACTORY_USERNAME_TOKEN')
         ARTIFACTORY_ARTIFACT_PATH = 'usw1.packages.broadcom.com/artifactory'
-        ARTIFACTORY_ARTIFACT_NPM_PATH = "${env.ARTIFACTORY_ARTIFACT_PATH}/api/npm/apim-npm-dev-local"
+        ARTIFACTORY_ARTIFACT_NPM_PATH = "${env.ARTIFACTORY_ARTIFACT_PATH}/api/npm/apim-npm-dev-local/"
         ARTIFACTORY_EMAIL = 'bld-apim.teamcity@broadcom.com'
     }
     parameters {
@@ -46,7 +46,7 @@ pipeline {
                    echo prepare per-project npmrc file
                    artifactoryCredentials=$(echo -n $ARTIFACTORY_CREDS_USR:$ARTIFACTORY_CREDS_PSW|base64 --wrap=0)
                    echo registry=https://$ARTIFACTORY_ARTIFACT_NPM_PATH > ./.npmrc
-                   echo //$ARTIFACTORY_ARTIFACT_NPM_PATH:_auth=$artifactoryCredentials >> ./.npmrc
+                   echo _auth=$artifactoryCredentials >> ./.npmrc
                    echo email=$ARTIFACTORY_EMAIL >> ./.npmrc
                    echo always-auth=true >> ./.npmrc
                    cat ./.npmrc

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
         ARTIFACTORY_CREDS = credentials('ARTIFACTORY_USERNAME_TOKEN')
         ARTIFACTORY_ARTIFACT_PATH = 'usw1.packages.broadcom.com/artifactory'
         ARTIFACTORY_ARTIFACT_NPM_PATH = "${env.ARTIFACTORY_ARTIFACT_PATH}/api/npm/apim-npm-dev-local/"
-        ARTIFACTORY_UPLOAD_PATH = "${env.ARTIFACTORY_ARTIFACT_PATH}/apim-npm-dev-local/@layer7/graphman/-/@layer7/"
+        ARTIFACTORY_UPLOAD_PATH = "${env.ARTIFACTORY_ARTIFACT_PATH}/apim-npm-dev-local/graphman-cli/"
         ARTIFACTORY_EMAIL = 'bld-apim.teamcity@broadcom.com'
     }
     parameters {

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 
 distDir=build/dist
-packageDir=build/graphman
-wrapperDir=build/graphman-cli
+packageDir=build/layer7-graphman
+wrapperDir=build/layer7-graphman-cli
 
 # copy required files to build main package
 echo cleaning build directory
@@ -31,14 +31,14 @@ cp cli-main.js $wrapperDir/.
 cp graphman.* $wrapperDir/.
 cp LICENSE.md $wrapperDir/
 pushd build>/dev/null
-tar -czvf graphman-cli.tar.gz *-cli
+tar -czvf layer7-graphman-cli.tar.gz *-cli
 popd>/dev/null
 
 mv $packageDir/*.tgz build/dist/.
 
-distPkg=$(ls -d ./build/dist/graphman-*.tgz)
+distPkg=$(ls -d ./build/dist/layer7-graphman-*.tgz)
 distPkg=${distPkg/graphman/graphman-cli}
-distPkg={distPkg/%.tgz/.tar.gz}
+distPkg=${distPkg/%.tgz/.tar.gz}
 mv build/*.tar.gz $distPkg
 echo build completed
 echo distribution packages

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 
 distDir=build/dist
-packageDir=build/layer7-graphman
-wrapperDir=build/layer7-graphman-wrapper
+packageDir=build/graphman
+wrapperDir=build/graphman-cli
 
 # copy required files to build main package
 echo cleaning build directory
@@ -31,11 +31,15 @@ cp cli-main.js $wrapperDir/.
 cp graphman.* $wrapperDir/.
 cp LICENSE.md $wrapperDir/
 pushd build>/dev/null
-tar -czvf layer7-graphman-wrapper.tar.gz *-wrapper
+tar -czvf graphman-cli.tar.gz *-cli
 popd>/dev/null
 
 mv $packageDir/*.tgz build/dist/.
-mv build/*.tar.gz build/dist/.
+
+distPkg=$(ls -d ./build/dist/graphman-*.tgz)
+distPkg=${distPkg/graphman/graphman-cli}
+distPkg={distPkg/%.tgz/.tar.gz}
+mv build/*.tar.gz $distPkg
 echo build completed
 echo distribution packages
 ls -l build/dist

--- a/cli-main.js
+++ b/cli-main.js
@@ -2,6 +2,7 @@
  * Copyright ©  2024. Broadcom Inc. and/or its subsidiaries. All Rights Reserved.
  */
 
+const module = process.env.GRAPHMAN_MODULE || "@layer7/graphman";
 const home = process.env.GRAPHMAN_HOME || __dirname;
 const args = process.argv.slice(2);
 const op = args[0];
@@ -13,7 +14,7 @@ if (fs.existsSync(home + "/modules/main.js")) {
         .call(home, op, args);
 } else {
     //running the client using npm module
-    graphman("@layer7/graphman")
+    graphman(module)
         .call(home, op, args);
 }
 


### PR DESCRIPTION
publishing the artifacts to local npm registry 
 - npm/apim-npm-dev-local

**@layer7/graphman** npm module will be avaialable from NPM registry.
Whereas, **layer7-graphman-cli.tar.gz** will be made available via github release. FYI, this is not a NPM module. It is a wrapper to consume the actual graphman module.
