### PR TITLE
having options available in pre_request extension

### DIFF
--- a/modules/graphman-operation-export.js
+++ b/modules/graphman-operation-export.js
@@ -49,9 +49,10 @@ module.exports = {
 
         utils.info(`exporting from ${gateway.name||gateway.address} gateway`);
         const request = graphman.request(gateway, query.options);
+        cli_options=Object.assign({},query.options);
         delete query.options;
         request.body = query;
-        graphman.invoke(request, callback);
+        graphman.invoke(request, callback, cli_options);
     },
 
     initParams: function (params, config) {

--- a/modules/graphman-operation-import.js
+++ b/modules/graphman-operation-import.js
@@ -47,6 +47,7 @@ module.exports = {
         }
 
         const request = graphman.request(gateway, query.options);
+        cli_options=query.options
         delete query.options;
         request.body = query;
 
@@ -59,7 +60,7 @@ module.exports = {
 
         graphman.invoke(request, function (data) {
             utils.writeResult(params.output, sanitizeMutationResult(data));
-        });
+        }, cli_options);
     },
 
     initParams: function (params, config) {

--- a/modules/graphman.js
+++ b/modules/graphman.js
@@ -220,9 +220,10 @@ module.exports = {
      * Makes the http request to the gateway's graphman service
      * @param options
      * @param callback
+     * @param cli_options
      */
-    invoke: function (options, callback) {
-        options = utils.extension("pre-request").apply(options, {});
+    invoke: function (options, callback, cli_options) {
+        options = utils.extension("pre-request").apply(options, cli_options);
         const req = ((!options.protocol||options.protocol === 'https'||options.protocol === 'https:') ? https : http).request(options, function(response) {
             let respInfo = {initialized: false, chunks: []};
 


### PR DESCRIPTION
Having all options, especially the cli ones available in the pre-request extension, is very helpful / necessary to control extension behavior by cli options.