### PR TITLE
NORALLY: fixing the diff multiline-text comparison -v1.3

### DIFF
--- a/modules/graphman-bundle.js
+++ b/modules/graphman-bundle.js
@@ -106,9 +106,9 @@ module.exports = {
     },
 
     reviseIDReferences: function (bundle, idMappings) {
-        this.forEach(bundle, (key, entities, typeInfo) => {
-            if (idMappings.mappings.goids.length) reviseIDReferences(entities, typeInfo, idMappings.mappings.goids);
-            if (idMappings.mappings.guids.length) reviseIDReferences(entities, typeInfo, idMappings.mappings.guids);
+        if (idMappings.mappings) this.forEach(bundle, (key, entities, typeInfo) => {
+            if (idMappings.mappings.goids.length) reviseIDReferences(entities, typeInfo, idMappings.mappings.goids, this);
+            if (idMappings.mappings.guids.length) reviseIDReferences(entities, typeInfo, idMappings.mappings.guids, this);
         });
     },
 
@@ -400,16 +400,16 @@ module.exports = {
     }
 }
 
-function reviseIDReferences(entities, typeInfo, mappings) {
+function reviseIDReferences(entities, typeInfo, mappings, butils) {
     entities.forEach(entity => {
         if (entity.policy) {
-            reviseIDReferencesInPolicies(entity, typeInfo, mappings);
+            reviseIDReferencesInPolicies(entity, typeInfo, mappings, butils);
         }
     });
 }
 
-function reviseIDReferencesInPolicies(entity, typeInfo, mappings) {
-    const name = this.entityName(entity, typeInfo);
+function reviseIDReferencesInPolicies(entity, typeInfo, mappings, butils) {
+    const name = butils.entityName(entity, typeInfo);
     mappings.forEach(mapping => {
         if (entity.policy.xml) entity.policy.xml = entity.policy.xml.replaceAll(mapping.left, function (match) {
             utils.info(`  revising ${name}, replacing ${mapping.left} with ${mapping.right}`);

--- a/modules/graphman-bundle.js
+++ b/modules/graphman-bundle.js
@@ -671,6 +671,14 @@ let importSanitizer = function () {
                         delete entity.goid;
                     }
 
+                    // convert policy-code into json-string equivalent
+                    if (entity.policy && entity.policy.code) {
+                        if (!entity.policy.json) {
+                            entity.policy.json = JSON.stringify(entity.policy.json, null, 4);
+                            delete entity.policy.code;
+                        }
+                    }
+
                     if (interestedSections.includes(typeInfo.pluralName)) {
                         sanitizeEntity(entity, typeInfo, butils);
                     }

--- a/modules/graphman-bundle.js
+++ b/modules/graphman-bundle.js
@@ -674,7 +674,8 @@ let importSanitizer = function () {
                     // convert policy-code into json-string equivalent
                     if (entity.policy && entity.policy.code) {
                         if (!entity.policy.json) {
-                            entity.policy.json = JSON.stringify(entity.policy.json, null, 4);
+                            utils.info(`  transforming the code field for the entity ` + butils.entityName(entity, typeInfo));
+                            entity.policy.json = JSON.stringify(entity.policy.code, null, 4);
                             delete entity.policy.code;
                         }
                     }

--- a/modules/graphman-bundle.js
+++ b/modules/graphman-bundle.js
@@ -105,6 +105,13 @@ module.exports = {
         return result;
     },
 
+    reviseIDReferences: function (bundle, idMappings) {
+        this.forEach(bundle, (key, entities, typeInfo) => {
+            if (idMappings.mappings.goids.length) reviseIDReferences(entities, typeInfo, idMappings.mappings.goids);
+            if (idMappings.mappings.guids.length) reviseIDReferences(entities, typeInfo, idMappings.mappings.guids);
+        });
+    },
+
     mappingInstruction: function (action, entity, typeInfo, flags) {
         flags = flags || {};
 
@@ -391,6 +398,34 @@ module.exports = {
         return Object.keys(fileSuffixes)
             .find(item => filename.endsWith(fileSuffixes[item] + ".json"));
     }
+}
+
+function reviseIDReferences(entities, typeInfo, mappings) {
+    entities.forEach(entity => {
+        if (entity.policy) {
+            reviseIDReferencesInPolicies(entity, typeInfo, mappings);
+        }
+    });
+}
+
+function reviseIDReferencesInPolicies(entity, typeInfo, mappings) {
+    const name = this.entityName(entity, typeInfo);
+    mappings.forEach(mapping => {
+        if (entity.policy.xml) entity.policy.xml = entity.policy.xml.replaceAll(mapping.left, function (match) {
+            utils.info(`  revising ${name}, replacing ${mapping.left} with ${mapping.right}`);
+            return mapping.right;
+        });
+
+        if (entity.policy.json) entity.policy.json = entity.policy.json.replaceAll(mapping.left, function (match) {
+            utils.info(`  revising ${name}, replacing ${mapping.left} with ${mapping.right}`);
+            return mapping.right;
+        });
+
+        if (entity.policy.yaml) entity.policy.yaml = entity.policy.yaml.replaceAll(mapping.left, function (match) {
+            utils.info(`  revising ${name}, replacing ${mapping.left} with ${mapping.right}`);
+            return mapping.right;
+        });
+    });
 }
 
 function sanitizeBaseUri(text) {

--- a/modules/graphman-extension-multiline-text-diff.js
+++ b/modules/graphman-extension-multiline-text-diff.js
@@ -3,6 +3,7 @@
  */
 
 const diffExtn = require('diff');
+const policyCodePathRegex = new RegExp("[.]policy[.](xml|json|yaml|code)$");
 
 module.exports = {
     /**
@@ -17,7 +18,7 @@ module.exports = {
      * @param context.typeInfo.pluralName input type information
      */
     apply: function (input, context) {
-        if (input.path.endsWith(".policy.xml") || input.path.endsWith(".policy.json") || input.path.endsWith(".policy.yaml")) {
+        if (policyCodePathRegex.test(input.path)) {
             input.diff = diffExtn.createTwoFilesPatch(
                 "target", "source",
                 input.target, input.source,

--- a/modules/graphman-operation-diff.js
+++ b/modules/graphman-operation-diff.js
@@ -71,8 +71,8 @@ module.exports = {
                 }
             }).catch(error => {
                 utils.error("errors encountered while analyzing the differences", error);
-                utils.error(`  name: ${error.name}`);
-                utils.error(`  message: ${error.message}`);
+                if (error.name) utils.error(`  name: ${error.name}`);
+                if (error.message) utils.error(`  message: ${error.message}`);
                 utils.print();
             });
         } else if (params["input-report"]) {
@@ -177,7 +177,13 @@ function readBundleFromGateway(gateway) {
                 data => {
                     if (data.errors) {
                         utils.warn(`errors detected while retrieving ${gateway.name} gateway configuration summary`);
-                        reject(data.errors);
+
+                        // if there's no data, report the errors via reject; otherwise, log them and proceed.
+                        if (!data.data) {
+                            reject(data.errors);
+                        } else {
+                            utils.error("errors encountered while analyzing the differences", data.errors);
+                        }
                     }
 
                     const bundle = data.data || {};

--- a/modules/graphman-operation-diff.js
+++ b/modules/graphman-operation-diff.js
@@ -71,6 +71,8 @@ module.exports = {
                 }
             }).catch(error => {
                 utils.error("errors encountered while analyzing the differences", error);
+                utils.error(`  name: ${error.name}`);
+                utils.error(`  message: ${error.message}`);
                 utils.print();
             });
         } else if (params["input-report"]) {

--- a/modules/graphman-operation-export.js
+++ b/modules/graphman-operation-export.js
@@ -147,16 +147,15 @@ module.exports = {
 
 function onExportDataCallback(data, parts, params) {
     if (data.data) {
+        if (data.errors) utils.warn("errors detected", data.errors);
+
         data = butils.sanitize(data.data, butils.EXPORT_USE, params.options);
         data = butils.removeDuplicates(data);
         butils.filter(data, params.filter);
         data = utils.extension("post-export").apply(data, {options: params.options});
         utils.writeResult(params.output, butils.sort(data));
-        if (parts) utils.writePartsResult(utils.parentPath(params.output), parts);
 
-        if (data.errors) {
-            utils.warn("errors detected", data.errors);
-        }
+        if (parts) utils.writePartsResult(utils.parentPath(params.output), parts);
     } else {
         utils.info("unexpected data", data);
     }

--- a/modules/graphman-operation-import.js
+++ b/modules/graphman-operation-import.js
@@ -13,6 +13,7 @@ module.exports = {
      * @param params
      * @param params.using mutation
      * @param params.input name of the input file containing the gateway configuration as bundle
+     * @param params.input-id-mappings name of the input file containing the id-mappings
      * @param params.variables name-value pairs used in mutation
      * @param params.gateway name of the gateway profile
      * @param params.output name of the output file
@@ -35,9 +36,12 @@ module.exports = {
             return;
         }
 
+        const inputIDMappings = params["input-id-mappings"] ? utils.readFile(params["input-id-mappings"]) : {};
         let inputBundle = butils.sanitize(utils.readFile(params.input), butils.IMPORT_USE, params.options);
         inputBundle = butils.removeDuplicates(inputBundle);
         butils.overrideMappings(inputBundle, params.options);
+        butils.reviseIDReferences(inputBundle, inputIDMappings);
+
         inputBundle = utils.extension("pre-import").apply(inputBundle, {options: params.options});
 
         const query = gql.generate(params.using, Object.assign(inputBundle, params.variables), params.options);
@@ -103,6 +107,9 @@ module.exports = {
         console.log();
         console.log("  --input <input-file>");
         console.log("    specify the name of input bundle file that contains gateway configuration");
+        console.log();
+        console.log("  --input-id-mappings <input-id-mappings-file>");
+        console.log("    specify the name of input file that contains id-mappings (i.e., goid/guid mapping differences identified between source and target environments)");
         console.log();
         console.log("  --variables.<name> <value>");
         console.log("    specify the name-value pair(s) for the variables section of the mutation-based query");

--- a/schema/v11.0.00-CR03/schema.graphql
+++ b/schema/v11.0.00-CR03/schema.graphql
@@ -3246,7 +3246,7 @@ extend type Mutation {
  A Layer7 gateway policy
 > @l7-entity policy|policies
 > @l7-identity-fields name,policyType
-> @l7-summary-fields goid,name,policyType,tag,subTag,checksum
+> @l7-summary-fields goid,guid,name,policyType,tag,subTag,checksum
 > @l7-excluded-fields policyRevision,policyRevisions
  """
  type L7Policy {

--- a/schema/v11.1.00/schema.graphql
+++ b/schema/v11.1.00/schema.graphql
@@ -2638,7 +2638,7 @@ extend type Mutation {
  A Layer7 gateway policy
 > @l7-entity policy|policies
 > @l7-identity-fields name,policyType
-> @l7-summary-fields goid,name,policyType,tag,subTag,checksum
+> @l7-summary-fields goid,guid,name,policyType,tag,subTag,checksum
 > @l7-excluded-fields policyRevision,policyRevisions
  """
  type L7Policy {

--- a/schema/v11.1.1/schema.graphql
+++ b/schema/v11.1.1/schema.graphql
@@ -3246,7 +3246,7 @@ extend type Mutation {
  A Layer7 gateway policy
 > @l7-entity policy|policies
 > @l7-identity-fields name,policyType
-> @l7-summary-fields goid,name,policyType,tag,subTag,checksum
+> @l7-summary-fields goid,guid,name,policyType,tag,subTag,checksum
 > @l7-excluded-fields policyRevision,policyRevisions
  """
  type L7Policy {


### PR DESCRIPTION
Diff fails to show the differences as multi-line for JSON format ([entity].policy.json) 
Diff fails to show the differences for CODE format([entity].policy.code) 
Diff fails to identify the GUID reference differences

Above issues are fixed by recomputing the JSON string with proper indentation.
Diff is extended to capture the id-mappings in separate file so that it can be piped to the import command.

Now, Diff, by default, results three files
 1. delta bundle
 2. report about the differences
 3. id-mappings

Individual output file names can be specified using CLI options. If output file name alone is specified, rest of the output file names are derived as below:
- delta.json
- delta.diff-report.json
- delta.id-mappings.json

Once the id-mappings are captured in a separate file, it can be used at **import** command.
`import --input some-bundle.json --input-id-mappings some.id-mappings.json`

