### PR TITLE
NORALLY:36412007: support goid/guid mappings when policy is encoded as code

### DIFF
--- a/modules/graphman-bundle.js
+++ b/modules/graphman-bundle.js
@@ -425,6 +425,15 @@ function reviseIDReferencesInPolicies(entity, typeInfo, mappings, butils) {
             utils.info(`  revising ${name}, replacing ${mapping.left} with ${mapping.right}`);
             return mapping.right;
         });
+
+        if (entity.policy.code) {
+            let codeString = JSON.stringify(entity.policy.code);
+            codeString = codeString.replaceAll(mapping.left, function (match) {
+                utils.info(`  revising ${name}, replacing ${mapping.left} with ${mapping.right}`);
+                return mapping.right;
+            });
+            entity.policy.code = JSON.parse(codeString);
+        }
     });
 }
 


### PR DESCRIPTION
When policy is encoded as code (i.e., JSON object), goid/guid mappings are not taking place during the **diff** bundle creation.

This change ensures goid/guid mappings even if policy is encoded as code.