### PR TITLE
NORALLY: incorrect l7 entity type detected

### DIFF
--- a/schema/v11.2.0/schema.graphql
+++ b/schema/v11.2.0/schema.graphql
@@ -5314,13 +5314,6 @@ type SampleMessage {
     serviceName: String
 }
 
-"""
-A SampleMessage Configuration.
-> @l7-entity
-> @l7-identity-fields name
-> @l7-summary-fields goid,name,checksum
-> @l7-excluded-fields
-"""
 input SampleMessageInput {
     "The goid for the SampleMessage"
     goid : ID


### PR DESCRIPTION
**SampleMessagesPayload** type was marked as L7Entity incorrectly.