### PR TITLE
NORALLY: masking the graphman issue DE663877

### DIFF
--- a/queries/encass.gql
+++ b/queries/encass.gql
@@ -7,7 +7,7 @@ query encassByName ($name: String!, $policyName: String!, $includeAllDependencie
         policy {
             xml
             allDependencies @include (if: $includeAllDependencies) {
-                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups}}
+                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups,-policyBackedServices}}
             }
         }
         policyRevision @include (if: $includePolicyRevision) {

--- a/queries/folder.gql
+++ b/queries/folder.gql
@@ -4,7 +4,7 @@ query folderContents ($folderPath: String!, $includeAllDependencies: Boolean = f
         policy {
             xml
             allDependencies @include (if: $includeAllDependencies) {
-                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups}}
+                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups,-policyBackedServices}}
             }
         }
         policyRevisions @include (if: $includePolicyRevisions) {
@@ -21,7 +21,7 @@ query folderContents ($folderPath: String!, $includeAllDependencies: Boolean = f
         policy {
             xml
             allDependencies @include (if: $includeAllDependencies) {
-                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups}}
+                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups,-policyBackedServices}}
             }
         }
         policyRevisions @include (if: $includePolicyRevisions) {

--- a/queries/policy.gql
+++ b/queries/policy.gql
@@ -4,7 +4,7 @@ query policyByName ($name: String!, $includeAllDependencies: Boolean = false, $i
          policy {
             xml
             allDependencies @include (if: $includeAllDependencies) {
-                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups}}
+                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups,-policyBackedServices}}
             }
         }
         policyRevisions @include (if: $includePolicyRevisions) {

--- a/queries/service.gql
+++ b/queries/service.gql
@@ -4,7 +4,7 @@ query serviceByResolutionPath ($resolutionPath: String!, $includeAllDependencies
          policy {
             xml
             allDependencies @include (if: $includeAllDependencies) {
-                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups}}
+                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups,-policyBackedServices}}
             }
         }
         policyRevisions @include (if: $includePolicyRevisions) {

--- a/queries/v11.2.0/folder.gql
+++ b/queries/v11.2.0/folder.gql
@@ -4,7 +4,7 @@ query folderContents ($folderPath: String!, $includeAllDependencies: Boolean = f
         policy {
             xml
             allDependencies @include (if: $includeAllDependencies) {
-                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups}}
+                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups,-policyBackedServices}}
             }
         }
         policyRevisions @include (if: $includePolicyRevisions) {
@@ -21,7 +21,7 @@ query folderContents ($folderPath: String!, $includeAllDependencies: Boolean = f
         policy {
             xml
             allDependencies @include (if: $includeAllDependencies) {
-                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups}}
+                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups,-policyBackedServices}}
             }
         }
         policyRevisions @include (if: $includePolicyRevisions) {

--- a/queries/v11.2.1/folder.gql
+++ b/queries/v11.2.1/folder.gql
@@ -4,7 +4,7 @@ query folderContents ($folderPath: String!, $includeAllDependencies: Boolean = f
         policy {
             xml
             allDependencies @include (if: $includeAllDependencies) {
-                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups}}
+                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups,-policyBackedServices}}
             }
         }
         policyRevisions @include (if: $includePolicyRevisions) {
@@ -21,7 +21,7 @@ query folderContents ($folderPath: String!, $includeAllDependencies: Boolean = f
         policy {
             xml
             allDependencies @include (if: $includeAllDependencies) {
-                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups}}
+                {{PolicyDependency:-policyFragments,-ldaps,-fips,-fipUsers,-fipGroups,-policyBackedServices}}
             }
         }
         policyRevisions @include (if: $includePolicyRevisions) {


### PR DESCRIPTION
Removing the policyBackedServices from policy-dependencies for masking the graphman issue.

FYI: [DE663877](https://rally1.rallydev.com/#/?detail=/defect/843715252677&fdp=true): Graphman fails to deliver policy-backed-service entities as policy dependencies when queried