### PR TITLE
[US1099766] Add feasibility in Jenkins job to run tests with desired schema

### DIFF
--- a/JenkinsTestfile
+++ b/JenkinsTestfile
@@ -100,7 +100,7 @@ pipeline {
                     if(!cfg.proxies)cfg.proxies={};
 
                     // If VAR_schema_version has value, set schema to use to run the tests
-                    echo "nag 1 VAR_gateway_primary_ip = params.VAR_schema_version"
+                    //echo "nag 1 VAR_gateway_primary_ip = params.VAR_schema_version"
                     echo "nag 2 VAR_gateway_primary_ip = ${VAR_schema_version}"
                     if("${VAR_schema_version}"?.trim() != '' || "${VAR_schema_version}"?.trim() != null) {
                         cfg.options.schema = "${VAR_schema_version}".trim()

--- a/JenkinsTestfile
+++ b/JenkinsTestfile
@@ -15,6 +15,7 @@ pipeline {
     }
     parameters {
         string(name: 'VAR_node_version', defaultValue: '16', description: 'Node.js major version (e.g. 16, 18, 20)')
+        string(name: 'VAR_schema_version', defaultValue: '', description: 'Schema version to use to run the tests (e.g. v11.1.3, v11.2.1)')
         booleanParam(name: 'RUN_COVERAGE', defaultValue: true, description: 'Run tests with coverage and publish report')
 
         // Default gateway
@@ -97,6 +98,11 @@ pipeline {
                     if(!cfg.credentials)cfg.credentials={};
                     if(!cfg.gateways)cfg.gateways={};
                     if(!cfg.proxies)cfg.proxies={};
+
+                    // If VAR_schema_version has value, set schema to use to run the tests
+                    if(VAR_schema_version != '' || VAR_schema_version != null) {
+                        cfg.options.schema = VAR_schema_version
+                    }
 
                     // HTTP Proxy
                     if(process.env.HTTP_PROXY_HOST && process.env.HTTP_PROXY_HOST.trim()!==""){

--- a/JenkinsTestfile
+++ b/JenkinsTestfile
@@ -144,6 +144,7 @@ pipeline {
                       cfg.gateways.default.credential="default";
                       cfg.gateways.default.rejectUnauthorized=process.env.DEFAULT_GW_REJECT_UNAUTHORIZED==="true";
                       cfg.gateways.default.allowMutations=process.env.DEFAULT_GW_ALLOW_MUTATIONS==="true";
+                      cfg.options.schema="v11.1.3";
                       if(process.env.DEFAULT_GW_PASSPHRASE)cfg.gateways.default.passphrase=process.env.DEFAULT_GW_PASSPHRASE;
                     }
 
@@ -158,6 +159,7 @@ pipeline {
                       cfg.gateways["source-gateway"].rejectUnauthorized=process.env.SOURCE_GW_REJECT_UNAUTHORIZED==="true";
                       cfg.gateways["source-gateway"].allowMutations=process.env.SOURCE_GW_ALLOW_MUTATIONS==="true";
                       cfg.gateways["source-gateway"].proxy="default";
+                      cfg.options.schema="v11.1.3";
                       if(process.env.SOURCE_GW_PASSPHRASE)cfg.gateways["source-gateway"].passphrase=process.env.SOURCE_GW_PASSPHRASE;
                     }
 
@@ -171,6 +173,7 @@ pipeline {
                       cfg.gateways["target-gateway"].credential="target";
                       cfg.gateways["target-gateway"].rejectUnauthorized=process.env.TARGET_GW_REJECT_UNAUTHORIZED==="true";
                       cfg.gateways["target-gateway"].allowMutations=process.env.TARGET_GW_ALLOW_MUTATIONS==="true";
+                      cfg.options.schema="v11.1.3";
                       if(process.env.TARGET_GW_PASSPHRASE)cfg.gateways["target-gateway"].passphrase=process.env.TARGET_GW_PASSPHRASE;
                     }
                     fs.writeFileSync(cfgFile,JSON.stringify(cfg,null,4));

--- a/JenkinsTestfile
+++ b/JenkinsTestfile
@@ -100,8 +100,8 @@ pipeline {
                     if(!cfg.proxies)cfg.proxies={};
 
                     // If VAR_schema_version has value, set schema to use to run the tests
-                    //echo "nag 1 VAR_gateway_primary_ip = params.VAR_schema_version"
-                    echo "nag 2 VAR_gateway_primary_ip = ${VAR_schema_version}"
+                    const schemaVersion = process.env.VAR_schema_version;
+                    console.log(`Using schema version: ${schemaVersion}`);
                     if("${VAR_schema_version}"?.trim() != '' || "${VAR_schema_version}"?.trim() != null) {
                         cfg.options.schema = "${VAR_schema_version}".trim()
                     }

--- a/JenkinsTestfile
+++ b/JenkinsTestfile
@@ -100,6 +100,8 @@ pipeline {
                     if(!cfg.proxies)cfg.proxies={};
 
                     // If VAR_schema_version has value, set schema to use to run the tests
+                    echo "nag 1 VAR_gateway_primary_ip = params.VAR_schema_version"
+                    echo "nag 2 VAR_gateway_primary_ip = ${VAR_schema_version}"
                     if("${VAR_schema_version}"?.trim() != '' || "${VAR_schema_version}"?.trim() != null) {
                         cfg.options.schema = "${VAR_schema_version}".trim()
                     }

--- a/JenkinsTestfile
+++ b/JenkinsTestfile
@@ -100,10 +100,9 @@ pipeline {
                     if(!cfg.proxies)cfg.proxies={};
 
                     // If VAR_schema_version has value, set schema to use to run the tests
-                    const schemaVersion = process.env.VAR_schema_version;
-                    console.log(`Using schema version: ${schemaVersion}`);
-                    if("${VAR_schema_version}"?.trim() != '' || "${VAR_schema_version}"?.trim() != null) {
-                        cfg.options.schema = "${VAR_schema_version}".trim()
+                    const schemaVersion = process.env.VAR_schema_version?.trim();
+                    if (schemaVersion) {
+                        cfg.options.schema = schemaVersion
                     }
 
                     // HTTP Proxy

--- a/JenkinsTestfile
+++ b/JenkinsTestfile
@@ -100,8 +100,8 @@ pipeline {
                     if(!cfg.proxies)cfg.proxies={};
 
                     // If VAR_schema_version has value, set schema to use to run the tests
-                    if(VAR_schema_version != '' || VAR_schema_version != null) {
-                        cfg.options.schema = VAR_schema_version
+                    if(params.VAR_schema_version?.trim() != '' || params.VAR_schema_version?.trim() != null) {
+                        cfg.options.schema = params.VAR_schema_version.trim()
                     }
 
                     // HTTP Proxy

--- a/JenkinsTestfile
+++ b/JenkinsTestfile
@@ -150,7 +150,6 @@ pipeline {
                       cfg.gateways.default.credential="default";
                       cfg.gateways.default.rejectUnauthorized=process.env.DEFAULT_GW_REJECT_UNAUTHORIZED==="true";
                       cfg.gateways.default.allowMutations=process.env.DEFAULT_GW_ALLOW_MUTATIONS==="true";
-                      cfg.options.schema="v11.1.3";
                       if(process.env.DEFAULT_GW_PASSPHRASE)cfg.gateways.default.passphrase=process.env.DEFAULT_GW_PASSPHRASE;
                     }
 
@@ -165,7 +164,6 @@ pipeline {
                       cfg.gateways["source-gateway"].rejectUnauthorized=process.env.SOURCE_GW_REJECT_UNAUTHORIZED==="true";
                       cfg.gateways["source-gateway"].allowMutations=process.env.SOURCE_GW_ALLOW_MUTATIONS==="true";
                       cfg.gateways["source-gateway"].proxy="default";
-                      cfg.options.schema="v11.1.3";
                       if(process.env.SOURCE_GW_PASSPHRASE)cfg.gateways["source-gateway"].passphrase=process.env.SOURCE_GW_PASSPHRASE;
                     }
 
@@ -179,7 +177,6 @@ pipeline {
                       cfg.gateways["target-gateway"].credential="target";
                       cfg.gateways["target-gateway"].rejectUnauthorized=process.env.TARGET_GW_REJECT_UNAUTHORIZED==="true";
                       cfg.gateways["target-gateway"].allowMutations=process.env.TARGET_GW_ALLOW_MUTATIONS==="true";
-                      cfg.options.schema="v11.1.3";
                       if(process.env.TARGET_GW_PASSPHRASE)cfg.gateways["target-gateway"].passphrase=process.env.TARGET_GW_PASSPHRASE;
                     }
                     fs.writeFileSync(cfgFile,JSON.stringify(cfg,null,4));

--- a/JenkinsTestfile
+++ b/JenkinsTestfile
@@ -100,8 +100,8 @@ pipeline {
                     if(!cfg.proxies)cfg.proxies={};
 
                     // If VAR_schema_version has value, set schema to use to run the tests
-                    if(params.VAR_schema_version?.trim() != '' || params.VAR_schema_version?.trim() != null) {
-                        cfg.options.schema = params.VAR_schema_version.trim()
+                    if("${VAR_schema_version}"?.trim() != '' || "${VAR_schema_version}"?.trim() != null) {
+                        cfg.options.schema = "${VAR_schema_version}".trim()
                     }
 
                     // HTTP Proxy


### PR DESCRIPTION
- Added new Jenkins param "VAR_schema_version" for User to enter the desired schema version, such that tests will use this schema instead of any default schema version
- If no value provided by User, then the default schema version will be used as it was working before

**Sample Jenkins results:**
https://apim-jenkins.devops.broadcom.net/job/gateway/job/tests/job/Graphman-Client-Ext/job/patch-5/7/

