### PR TITLE
DE670506: fixing the filter CLI options for export and slice operations

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -46,16 +46,13 @@ This will install:
    **Linux/Mac:**
    ```bash
    export GRAPHMAN_HOME=/path/to/graphman-client
-   ```
-
-   **Windows (PowerShell):**
-   ```powershell
-   $env:GRAPHMAN_HOME = "C:\path\to\graphman-client"
+   export GRAPHMAN_ENTRYPOINT=./graphman.sh
    ```
 
    **Windows (Command Prompt):**
    ```cmd
    set GRAPHMAN_HOME=C:\path\to\graphman-client
+   set GRAPHMAN_ENTRYPOINT=graphman.sh
    ```
 
 2. **Configure Gateway Connection** (for integration tests):

--- a/TESTING.md
+++ b/TESTING.md
@@ -52,7 +52,7 @@ This will install:
    **Windows (Command Prompt):**
    ```cmd
    set GRAPHMAN_HOME=C:\path\to\graphman-client
-   set GRAPHMAN_ENTRYPOINT=graphman.sh
+   set GRAPHMAN_ENTRYPOINT=graphman.bat
    ```
 
 2. **Configure Gateway Connection** (for integration tests):

--- a/modules/graphman-bundle.js
+++ b/modules/graphman-bundle.js
@@ -175,20 +175,28 @@ module.exports = {
     },
 
     filter: function (bundle, filter) {
-        if (!filter || !filter.by) return;
-        if (!filter.equals && !filter.startsWith && !filter.endsWith && !filter.contains) return;
+         if (!filter) return;
+
+        if (!filter.by) {
+            const predicates = filterer.buildPredicates(filter);
+            this.forEach(bundle, (_section, _entities, typeInfo) =>
+                filterer.filterEntities(bundle, typeInfo, predicates));
+            return;
+        }
+
+        utils.warn(" deprecated filter options are in use, please use the latest filter options");
 
         Object.keys(bundle).filter(key => Array.isArray(bundle[key])).forEach(key => {
             const list = [];
             bundle[key].forEach(item => {
                 let match = item.hasOwnProperty(filter.by);
 
-                if (filter.equals) match &= (item[filter.by].toString() === filter.equals);
-
-                if (typeof item[filter.by] === 'string') {
-                    if (filter.startsWith) match &= item[filter.by].startsWith(filter.startsWith);
-                    if (filter.endsWith) match &= item[filter.by].endsWith(filter.endsWith);
-                    if (filter.contains) match &= item[filter.by].includes(filter.contains);
+                if (filter.equals) {
+                    match = match && (item[filter.by].toString() === filter.equals);
+                } else if (typeof item[filter.by] === 'string') {
+                    if (filter.startsWith) match = match && item[filter.by].startsWith(filter.startsWith);
+                    if (filter.endsWith) match = match && item[filter.by].endsWith(filter.endsWith);
+                    if (filter.contains) match = match && item[filter.by].includes(filter.contains);
                 }
 
                 if (match) list.push(item);
@@ -810,14 +818,9 @@ let filterer = function () {
         },
     };
 
-    const supported_predicates_regex = /^(eq|neq|regex|gt|gte|lt|lte)[.]/;
-
     function toPredicateFieldConfig(name, value) {
-        const valueString = String(value);
-        const match = valueString.match(supported_predicates_regex);
-        const pfConfig = match ?
-            {name: name, criteria: match[1], value: valueString.substring(match[1].length + 1)} :
-            {name: name, criteria: 'eq', value: value};
+        const values = Array.isArray(value) ? value : ["eq", value];
+        const pfConfig = {name: name, criteria: values[0], value: values[1]};
         if (pfConfig.criteria === "regex") {
             pfConfig.value = new RegExp(pfConfig.value);
         }
@@ -838,52 +841,19 @@ let filterer = function () {
                 if (predicate) {
                     return predicate.test(entity[pfConfig.name], pfConfig.value, pfConfig);
                 } else {
-                    return true;
+                    return false;
                 }
             });
         };
     }
 
-    function buildDefaultPredicate(filter) {
-        let defaultPredicate = buildPredicate(filter['*']) || function (entity, typeInfo) {
-            return true;
-        };
-
-        if (!filter.by) {
-            return defaultPredicate;
-        }
-
-        const pfConfig = {name: filter.by, criteria: 'eq', value: null};
-        if (filter.equals) {
-            pfConfig.value = filter.equals;
-        } else if (filter.startsWith) {
-            pfConfig.value = filter.startsWith;
-            pfConfig.criteria = 'eq%';
-        } else if (filter.endsWith) {
-            pfConfig.value = filter.endsWith;
-            pfConfig.criteria = '%eq';
-        } else if (filter.contains) {
-            pfConfig.value = filter.contains;
-            pfConfig.criteria = '%eq%';
-        } else {
-            utils.warn('expected value is missing for the filter, ignoring it');
-            pfConfig.criteria = '';
-        }
-
-        const predicate = supported_predicates[pfConfig.criteria];
-        if (predicate) defaultPredicate = function (entity, typeInfo) {
-            return predicate.test(entity[pfConfig.name], pfConfig.value, pfConfig);
-        };
-
-        return defaultPredicate;
-    }
-
     return {
         filterEntities: function (bundle, typeInfo, predicates) {
             const entities = bundle[typeInfo.pluralName];
+            const predicate = predicates.get(typeInfo.pluralName);
 
-            if (entities) {
-                const predicate = predicates.get([typeInfo.pluralName]);
+            if (entities && predicate) {
+                utils.info("filtering " + typeInfo.pluralName);
                 const result = entities.filter(item => predicate(item, typeInfo));
                 if (result.length === 0) {
                     delete bundle[typeInfo.pluralName];
@@ -897,14 +867,13 @@ let filterer = function () {
             const predicates = {
                 get: function (section) {
                     if (predicates[section] === undefined) {
-                        predicates[section] = buildPredicate(filter[section]) || predicates['default'];
+                        predicates[section] = buildPredicate(filter[section]);
                     }
 
                     return predicates[section];
                 }
             };
 
-            predicates['default'] = buildDefaultPredicate(filter);
             return predicates;
         }
     }

--- a/modules/graphman-operation-export.js
+++ b/modules/graphman-operation-export.js
@@ -130,11 +130,10 @@ module.exports = {
         console.log("    specify the name of file to capture the exported configuration.");
         console.log("    when skipped, output will be written to the console.");
         console.log();
-        console.log("  --filter.<section>.<field-name> [<matching-criteria>.]<field-value>]");
+        console.log("  --filter.<section>.<field-name> [<matching-criteria>] <field-value>");
         console.log("    use this option to filter the exported entities by one or more fields at section level");
         console.log("    section refers to the plural name of the entity type");
         console.log("    multiple fields used for section-level filtering will be chained together by and-logic");
-        console.log("    use '*' as a section for defining the global level filter; will only be used when no specific filters are defined for a given section");
         console.log("    supported matching criteria are");
         console.log("      eq, equals");
         console.log("      neq, not equals");

--- a/modules/graphman-operation-export.js
+++ b/modules/graphman-operation-export.js
@@ -110,7 +110,7 @@ module.exports = {
     usage: function () {
         console.log("export --using <query> [--variables.<name> <value>,...] [--gateway <name>]");
         console.log("  [--output <output-file>]");
-        console.log("  [--filter.by <entity-field-name> --filter.<matching-criteria> <value>,...]");
+        console.log("  [--filter.<section>.<field-name> <matching-criteria> <field-value>,...]");
         console.log("  [--options.<name> <value>,...]");
         console.log();
         console.log("Exports gateway configuration using a specified query. If the query doesn't exist, client tries to generate a query dynamically.");

--- a/modules/graphman-operation-slice.js
+++ b/modules/graphman-operation-slice.js
@@ -70,6 +70,7 @@ module.exports = {
     usage: function () {
         console.log("slice --input <input-file> [--sections <section> <section>...]");
         console.log("  [--output <output-file>]");
+        console.log("  [--filter.<section>.<field-name> <matching-criteria> <field-value>,...]");
         console.log();
         console.log("Slices the bundle as per the choice.");
         console.log("When similar entities are encountered, entities from the rightmost bundle takes the precedence.");

--- a/modules/graphman-operation-slice.js
+++ b/modules/graphman-operation-slice.js
@@ -10,6 +10,7 @@ module.exports = {
      * @param params
      * @param params.input input bundle file
      * @param params.sections one or more sections of bundle
+     * @param params.filter section specific filters
      * @param params.output output bundle
      */
     run: function (params) {
@@ -50,11 +51,7 @@ module.exports = {
             }
         }
 
-        if (params.filter) {
-            delete params.filter.by;
-            butils.filter(result, params.filter);
-        }
-
+        butils.filter(result, params.filter);
         utils.writeResult(params.output, butils.sort(result));
     },
 
@@ -86,11 +83,10 @@ module.exports = {
         console.log("    * is a special section name, used to refer all the sections of a bundle");
         console.log("    use '-' prefix to exclude the section");
         console.log();
-        console.log("  --filter.<section>.<field-name> [<matching-criteria>.]<field-value>]");
+        console.log("  --filter.<section>.<field-name> [<matching-criteria>] <field-value>");
         console.log("    use this option to filter the entities by one or more fields at section level");
         console.log("    section refers to the plural name of the entity type");
         console.log("    multiple fields used for section-level filtering will be chained together by and-logic");
-        console.log("    use '*' as a section for defining the global level filter; will only be used when no specific filters are defined for a given section");
         console.log("    supported matching criteria are");
         console.log("      eq, equals");
         console.log("      neq, not equals");

--- a/tests/slice.test.js
+++ b/tests/slice.test.js
@@ -181,7 +181,7 @@ describe("slice command", () => {
         const output = graphman("slice", 
             "--input", bundle, 
             "--sections", "services",
-            "--filter.services.name", "regex.Service[12]");
+            "--filter.services.name", "regex", "Service[12]");
 
         expect(output.services).toHaveLength(2);
         expect(output.services).toEqual(expect.arrayContaining([


### PR DESCRIPTION
- Currently, filter (client-side) specific CLI options are supported for export and slice operations. They are not working as expected.
- Recent filter enhancements seemed incomplete. 
- With this, filter enhancements should be active and working as expected.